### PR TITLE
Allow the encoder to return early if input packets are different sizes

### DIFF
--- a/input_network_encoder.cpp
+++ b/input_network_encoder.cpp
@@ -215,6 +215,10 @@ void InputNetworkEncoder::reset_inputs_to_defaults(LocalVector<Variant> &r_input
 }
 
 bool InputNetworkEncoder::are_different(DataBuffer &p_buffer_A, DataBuffer &p_buffer_B) const {
+	if (p_buffer_A.size() != p_buffer_B.size()) {
+		return true;
+	}
+
 	for (uint32_t i = 0; i < input_info.size(); i += 1) {
 		const NetworkedInputInfo &info = input_info[i];
 


### PR DESCRIPTION
The input encoder was assuming that all packets are the same size and encoded in the same way, but this is not the case. Added a check to make sure that we don't try to read the buffer if the sizes are different, and also don't try to read if the default value bool is different.